### PR TITLE
Arm neon

### DIFF
--- a/src/configure
+++ b/src/configure
@@ -118,7 +118,7 @@ else
 fi
 
 echo "PREFIX       = $prefix"              >>Makefile
-echo "INCLUDE      = -I../npy_array"       >>Makefile
+echo "INCLUDE      = -I../npy_array -I/home/oystein/optimized-routines/math/include"       >>Makefile
 if $debugsym; then
     echo 'dbg          = -g'               >>Makefile
 fi
@@ -145,6 +145,10 @@ if grep -q neon "/proc/cpuinfo"; then
   cpuinfo+="-mfpu=neon "
 fi
 
+if grep -q asimd "/proc/cpuinfo"; then
+  cpuinfo+="-march=native -mtune=cortex-a72 "
+fi
+
 echo 'arch = '$cpuinfo''                   >>Makefile
 
 if $have_pkg_config; then
@@ -153,4 +157,4 @@ if $have_pkg_config; then
 fi
     
 echo "include Makefile.in"                 >>Makefile
-echo "configure done, type 'make' to build."
+echo "configure done, type 'make' to build"

--- a/src/matrix_operations.c
+++ b/src/matrix_operations.c
@@ -90,9 +90,8 @@ void vector_vector_outer( int n_rows, int n_cols, const float *x, const float *y
             }
 #endif  /* __AVX__ */
 #ifdef __ARM_NEON__
-	    float32x4_t scale = vdupq_n_f32( a );
             for( ; j <= ((n_cols)-4); j += 4, y_ptr += 4, matrix_ptr += 4) {
-                vst1q_f32( matrix_ptr, vmulq_f32( scale, vld1q_f32( y_ptr )) );
+                vst1q_f32( matrix_ptr, vmulq_n_f32( vld1q_f32( y_ptr ), a ) );
             }
 #endif  /* __ARM_NEON__ */
             for( ; j < n_cols; j++ )


### PR DESCRIPTION
This is just a beginning. There are still some issues.

**Important:** You have to change all preprocessor ifdef's from `#ifdef __ARM_NEON__` to `#if defined(__ARM_NEON) || defined(__ARM_NEON__)`

Also if `__aarch64__` is defined the library mathlib library from https://github.com/ARM-software/optimized-routines should be used for a vectorized exponential function.

Also... we want to support both GCC and CLANG as compilers and both armv7 and armv8 this will require some logic in the `configure` script.
