### PR TITLE
Dynamic loading of activation functions is default again - and fixed …

### DIFF
--- a/src/configure
+++ b/src/configure
@@ -70,7 +70,7 @@ for arg in "$@"; do
         echo '  --disable-debug:     do not include debug symbols'
         echo '  --enable-profile:    include profile symbols (default off)'
         echo '  --disable-profile:   do not include profile symbols'
-        echo '  --enable-shared:     build dynamic linked library. (default on)'
+        echo '  --enable-shared:     build dynamic linked library. (default off)'
         echo '  --disable-shared:    build static linked library'
         echo 'all invalid options are silently ignored'
         exit 0

--- a/src/neuralnet.c
+++ b/src/neuralnet.c
@@ -182,7 +182,6 @@ load_error:
         free( activation_funcs[0] );
         free( activation_funcs );
     }
-
     return nn;
 }
 


### PR DESCRIPTION
…some bug

Nothing much actually.
 * cleaup_dynamic_symbols() is now static. 
 * Add the record in the linked list even if derivative isn't found.
 * Improved some error messages.
 * Build the library static by default.
 
(I notice a "still reachable" memory leak when compiling dynamic... 8 bytes - I won't worry too much though.)

-Ø