### PR TITLE
Ah! configure of examples doesn't get the compile flags right

### DIFF
--- a/examples/configure
+++ b/examples/configure
@@ -75,10 +75,10 @@ if grep -q avx512f "/proc/cpuinfo"; then
 fi
 
 if grep -q fma "/proc/cpuinfo"; then
-  arch_opt+="-mfma "
+  cpuinfo+="-mfma "
 fi
-echo "Architecture options: $arch_opt ..."
-echo 'arch = '$arch_opt'' >> Makefile
+echo "Architecture options: $cpuinfo ..."
+echo 'arch = '$cpuinfo'' >> Makefile
 
 echo 'include Makefile.in' >>Makefile
 echo 'Configuration complete, type make to build.'


### PR DESCRIPTION
Yes! No wonder example_01 crashed. It was compiled with the wrong options.