### PR TITLE
padding on work memory

### DIFF
--- a/src/matrix_operations.c
+++ b/src/matrix_operations.c
@@ -87,16 +87,16 @@ void vector_vector_outer( int n_rows, int n_cols, const float *x, const float *y
             float *matrix_ptr = matrix + ( i * n_cols );
             const float *y_ptr = y;
 #ifdef __AVX512F__
-            __m512 scales = _mm512_set1_ps( a );
+            __m512 scale512 = _mm512_set1_ps( a );
             for( ; j <= ((n_cols)-16); j += 16, y_ptr += 16, matrix_ptr += 16) {
-                _mm512_storeu_ps( matrix_ptr, _mm512_mul_ps( scales, _mm512_loadu_ps( y_ptr )) );
+                _mm512_storeu_ps( matrix_ptr, _mm512_mul_ps( scale512, _mm512_loadu_ps( y_ptr )) );
             }
 #endif  /* __AVX512F__ */
 #ifdef __AVX__
-            __m256 scale = _mm256_set1_ps( a );
+            __m256 scale256 = _mm256_set1_ps( a );
             for( ; j <= ((n_cols)-8); j += 8, y_ptr += 8, matrix_ptr += 8) {
                 /* Unforuneately this has to go unaligned. Can that be fixed? */
-                _mm256_storeu_ps( matrix_ptr, _mm256_mul_ps( scale, _mm256_loadu_ps( y_ptr )) );
+                _mm256_storeu_ps( matrix_ptr, _mm256_mul_ps( scale256, _mm256_loadu_ps( y_ptr )) );
             }
 #endif  /* __AVX__ */
             for( ; j < n_cols; j++ )

--- a/src/matrix_operations.c
+++ b/src/matrix_operations.c
@@ -60,7 +60,7 @@ void matrix_vector_multiply( int n_rows, int n_cols, const float *matrix, const 
         __m256 sum = _mm256_setzero_ps ();
         for (; j <= ((n_cols)-8); j += 8, m_ptr += 8, v_ptr += 8){ /* Check if faster: unroll w prefetch */
 #if defined(__FMA__)
-            sum = _mm256_fmadd_ps( _mm256_load_ps(v_ptr), _mm256_load_ps(m_ptr), sum);
+            sum = _mm256_fmadd_ps( _mm256_loadu_ps(v_ptr), _mm256_load_ps(m_ptr), sum);
 #else
             sum = _mm256_add_ps (sum, _mm256_mul_ps(_mm256_load_ps(v_ptr), _mm256_load_ps(m_ptr)));
 #endif

--- a/src/neuralnet.c
+++ b/src/neuralnet.c
@@ -258,6 +258,7 @@ void neuralnet_predict( const neuralnet_t *nn, const float *input, float *out )
     activations[1] = workmem;
     for( int i = 1; i < nn->n_layers-1; i++) {
         int size_w_padding = (nn->layer[i-1].n_output + floats_per_simd_register - 1) / floats_per_simd_register;
+        size_w_padding *= floats_per_simd_register;
         activations[i+1] = activations[i] + size_w_padding;
         assert( is_aligned( activations[i+1] ));
     }
@@ -491,6 +492,7 @@ void neuralnet_backpropagation( const neuralnet_t *nn, const float *input, const
     activations[1] = workmem;
     for( int i = 1; i < nn->n_layers; i++) {
         int size_w_padding = (nn->layer[i-1].n_output + floats_per_simd_register - 1) / floats_per_simd_register;
+        size_w_padding *= floats_per_simd_register;
         activations[i+1] = activations[i] + size_w_padding;
         assert( is_aligned( activations[i+1] ));
     }

--- a/src/neuralnet.c
+++ b/src/neuralnet.c
@@ -189,24 +189,7 @@ neuralnet_t *neuralnet_load( const char *filename)
             }
         }
 
-        /*
-        printf( "copy data from (%dx%d) matrix into a (%dx%d) matrix.\n",
-             weights->shape[0], weights->shape[1],
-             nn->layer[i].n_input, nn->layer[i].n_output );
-        */
-        if( ((int)weights->shape[0] == nn->layer[i].n_input) && ((int)weights->shape[1] == nn->layer[i].n_output)) { 
-            /* No resize */
-            memcpy( nn->layer[i].weight, weights->data, weights->shape[0] * weights->shape[1] * sizeof(float));
-        } else {
-            /* The neural network layer has been resized to match the SIMD register size. */
-            /* Step one: Set all weights to 0 */
-            memset( nn->layer[i].weight, 0, nn->layer[i].n_input * nn->layer[i].n_output * sizeof(float));
-            /* Step two: copy row by row */
-            for( int j = 0; j < (int) weights->shape[0]; j++ )
-                memcpy( nn->layer[i].weight + (j * nn->layer[i].n_output), /* dest */
-                        (float*) weights->data + (j * weights->shape[1]),  /* src  */
-                        weights->shape[1] * sizeof(float));                /* size */
-        }
+        memcpy( nn->layer[i].weight, weights->data, weights->shape[0] * weights->shape[1] * sizeof(float));
         /* Debug 
         print_matrix( weights->shape[0], weights->shape[1], (float*) weights->data );
         print_matrix( nn->layer[i].n_input, nn->layer[i].n_output, nn->layer[i].weight );
@@ -269,13 +252,15 @@ void neuralnet_predict( const neuralnet_t *nn, const float *input, float *out )
     for( int i = 0; i < nn->n_layers; i++)
         workmem_sz += nn->layer[i].n_output; // + nn->layer[i].n_float_padding;
 
-    float SIMD_ALIGN(workmem[ workmem_sz ]);
+    float SIMD_ALIGN(workmem[ workmem_sz + (floats_per_simd_register * nn->n_layers) ]);
     float *activations[nn->n_layers+1];
     activations[0] = (float*) input;
     activations[1] = workmem;
-    for( int i = 1; i < nn->n_layers-1; i++)
-        activations[i+1] = activations[i] + nn->layer[i-1].n_output; // + nn->layer[i-1].n_float_padding;
-    
+    for( int i = 1; i < nn->n_layers-1; i++) {
+        int size_w_padding = (nn->layer[i-1].n_output + floats_per_simd_register - 1) / floats_per_simd_register;
+        activations[i+1] = activations[i] + size_w_padding;
+        assert( is_aligned( activations[i+1] ));
+    }
     activations[nn->n_layers] = out;
 
     /* Debug */
@@ -500,12 +485,15 @@ void neuralnet_backpropagation( const neuralnet_t *nn, const float *input, const
     for( int i = 0; i < nn->n_layers; i++)
         workmem_sz += nn->layer[i].n_output;
 
-    float SIMD_ALIGN(workmem[ workmem_sz + nn->layer[0].n_input ]);
+    float SIMD_ALIGN(workmem[ workmem_sz + nn->layer[0].n_input + (floats_per_simd_register * nn->n_layers) ]);
     float *activations[nn->n_layers+1];
     activations[0] = (float*) input;
     activations[1] = workmem;
-    for( int i = 1; i < nn->n_layers; i++)
-        activations[i+1] = activations[i] + nn->layer[i-1].n_output;
+    for( int i = 1; i < nn->n_layers; i++) {
+        int size_w_padding = (nn->layer[i-1].n_output + floats_per_simd_register - 1) / floats_per_simd_register;
+        activations[i+1] = activations[i] + size_w_padding;
+        assert( is_aligned( activations[i+1] ));
+    }
     
     /* forward */
     for( int i = 0; i < nn->n_layers; i++){
@@ -648,19 +636,6 @@ neuralnet_t * neuralnet_create( const int n_layers, int sizes[], char *activatio
         return NULL;
     }
 
-#ifndef USE_CBLAS
-    /* OK - resize "bad" sized */
-    int resizes[n_layers + 1];
-    memcpy( resizes, sizes, (n_layers + 1) * sizeof(int));
-    for( int i = 1; i < n_layers; i++ ){
-        int num_of_simd_reg = ( sizes[i] +  floats_per_simd_register - 1 ) / floats_per_simd_register;
-        resizes[i] = num_of_simd_reg * floats_per_simd_register;
-
-        if (sizes[i] != resizes[i] ) /* We did a resize */
-            fprintf( stderr, "INFO - Neural network size is resized to match CPUs SIMD registers.\nINFO - Hidden size %d is resized to %d.\n",
-                    sizes[i], resizes[i] );
-    }
-#endif
     neuralnet_t *nn;
     /* The neural network itself doesn't need to be aligned */
     if ( (nn = malloc( sizeof( neuralnet_t ))) == NULL ){  
@@ -678,13 +653,8 @@ neuralnet_t * neuralnet_create( const int n_layers, int sizes[], char *activatio
     }
 
     for( int i = 0; i < nn->n_layers; i++ ){
-#ifdef USE_CBLAS
         nn->layer[i].n_input  = sizes[i];
         nn->layer[i].n_output = sizes[i+1];
-#else
-        nn->layer[i].n_input  = resizes[i];
-        nn->layer[i].n_output = resizes[i+1];
-#endif
     }
 
     if( !_weights_memory_allocate( nn )){

--- a/tests/Makefile.in
+++ b/tests/Makefile.in
@@ -30,7 +30,7 @@ endif
 
 CFLAGS += $(DEFINE)
 
-testprogs = test_neuralnet test_sgd test_backpropagation test_activation test_loss test_metrics
+testprogs = test_neuralnet test_oddsizes test_sgd test_backpropagation test_activation test_loss test_metrics
 
 all: $(testprogs) 
 

--- a/tests/test_neuralnet.c
+++ b/tests/test_neuralnet.c
@@ -33,12 +33,7 @@ int main(int argc, char *argv[] )
             floats_per_simd_register==16 ? "AVX512" : 
             floats_per_simd_register==8 ? "AVX/AVX2" : 
             floats_per_simd_register==4 ? "SSE" : "No SIMD");
-#ifdef USE_CBLAS
     const int n_param_342 = 26;
-#else
-    const int n_param_342 = floats_per_simd_register == 16 ? 98 :
-                        floats_per_simd_register == 8  ? 50 : 26;
-#endif
     printf( "I believe the number of parameters should be: %d\n", n_param_342 );
 
     CHECK_INT_EQUALS_MSG( n_param_342, neuralnet_total_n_parameters(nn),
@@ -77,9 +72,6 @@ int main(int argc, char *argv[] )
 
     CHECK_NOT_NULL_MSG( nn,
             "Checking that neural network was created" );
-#if !(defined USE_CBLAS) && floats_per_simd_register == 16 
-    n_out += 8;
-#endif
 
     srand(time(0));
 

--- a/tests/test_oddsizes.c
+++ b/tests/test_oddsizes.c
@@ -41,10 +41,10 @@ int main(int argc, char *argv[] )
         /* Count number of layers by counting the number of activation functions given */
         int n_layers = 0; char **p = test_cases[i].activations;
         while( *p++ ) n_layers++;
-        
+
         neuralnet_t *nn = neuralnet_create( n_layers,
                 test_cases[i].sizes, test_cases[i].activations);
-    
+
         CHECK_NOT_NULL_MSG( nn,
                 "Checking that neural network was created" );
 
@@ -66,7 +66,7 @@ int main(int argc, char *argv[] )
         printf("Predictions:\n");
         for( int j = 0; j < nn_n_output; j++)
             printf("%6.6f\n", output[j]);
-        
+
         /* Try one backward calc. */
         neuralnet_set_loss( nn, test_cases[i].loss );
         for( int j = 0; j < nn_n_output; j++)

--- a/tests/test_oddsizes.c
+++ b/tests/test_oddsizes.c
@@ -1,0 +1,79 @@
+#include "test.h"
+#include "neuralnet.h"
+#include "simd.h"
+#include <stdlib.h>
+#include <string.h>
+#include <stdio.h>
+#include <unistd.h>
+#include <assert.h>
+#include <time.h>
+
+struct nntest {
+    int  *sizes;
+    char **activations;
+    char *loss;
+} test_sizes[3] = {
+    { .sizes = INT_ARRAY( 231, 128, 5),
+      .activations = STR_ARRAY("relu", "sigmoid"),
+      .loss = "binary_crossentropy" },
+    { .sizes = INT_ARRAY( 53, 19, 13, 7),
+      .activations = STR_ARRAY("relu", "tanh", "sigmoid"),
+      .loss = "binary_crossentropy"},
+    { .sizes = INT_ARRAY( 103, 53, 19, 13, 7),
+      .activations = STR_ARRAY("relu", "hard_sigmoid", "tanh", "softmax"),
+      .loss = "categorical_crossentropy" },
+};
+
+int main(int argc, char *argv[] )
+{
+    int test_count = 0;
+    int fail_count = 0;
+
+    if(argc == 1)
+        fprintf(stderr, KBLU "Running '%s'\n" KNRM, argv[0] );
+
+    for( int i = 0; i < 3; i++ ){
+        fprintf(stderr, KBLU "Creating neural network %d\n" KNRM, i+1 );
+        neuralnet_t *nn = neuralnet_create( i+2,
+                test_sizes[i].sizes, test_sizes[i].activations);
+    
+        CHECK_NOT_NULL_MSG( nn,
+                "Checking that neural network was created" );
+
+        int nn_n_input = nn->layer[0].n_input;
+        int nn_n_output = nn->layer[nn->n_layers-1].n_output;
+
+        neuralnet_initialize(nn, NULL);
+
+        float *input = simd_malloc( nn_n_input * sizeof(float) );
+        float *output = simd_malloc( nn_n_output * sizeof(float) );
+        float *target = simd_malloc( nn_n_output * sizeof(float) );
+        float *grad = simd_malloc( neuralnet_total_n_parameters(nn) * sizeof(float) );
+
+        /* Try forward calc. */
+        for( int j = 0; j < nn_n_input; j++)
+            input[j] = 1.0f;
+
+        neuralnet_predict( nn, input, output);
+        printf("Predictions:\n");
+        for( int j = 0; j < nn_n_output; j++)
+            printf("%6.6f\n", output[j]);
+        
+        /* Try one backward calc. */
+        neuralnet_set_loss( nn, test_sizes[i].loss );
+        for( int j = 0; j < nn_n_output; j++)
+            target[j] = 1.0f;
+        neuralnet_backpropagation( nn, input, target, grad );
+
+        printf("Some random gradient value: %6.6f\n", grad[10]);
+        /*  clean up */
+        simd_free( input );
+        simd_free( output );
+        simd_free( target );
+        simd_free( grad );
+
+        neuralnet_free( nn );   
+    }
+    print_test_summary(test_count, fail_count );
+    return 0;
+}


### PR DESCRIPTION
Try to revert the "resize" commit a from October. Use unaligned load and store in the vector matrix operations instead.

The idea is to maybe get away with this without having to resize. Maybe the gradient can be aligned as well if that can save some cycles.