### PR TITLE
Use blas to evaluate several samples

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,16 @@
 # simd_neuralnet
 Feed-forward neural network implementation in C with SIMD instructions.
 
-BTW: simd_neuralnet is a bit of a misnomer. It is not SIMD instructions apart from AVX and AVX2 instructions in some of the most heavy functions. Can anyone come up with a better name? It is a neural network library written in C. I'm not sure what else makes this library different from the other libraries out there.
+BTW: simd_neuralnet is a bit of a misnomer. It is not SIMD instructions apart from AVX, AVX2
+and AVX512 instructions in some of the most heavy functions. Can anyone come up with a better name?
+It is a neural network library written in C. I'm not sure what else makes this library different
+from the other libraries out there.
+
+It is very fast compared to other libraries like Keras and PyTorch - just give it a try and you
+will see.
 
 ## The idea.
-At current this is just a study project for myself to improve my abilities to implement a 
+This project started out as a study project for myself to improve my abilities to implement a 
 feed forward neural network in C. A lot of this code will be based on code from some of my
 other projects. Hopefully this will be generally usable.
 
@@ -26,7 +32,8 @@ struggle with python bindings or slow memory transfers to GPU memory.
 ## Limitations
 To be able to achieve the above, we need to set some limitations.
 
- * **`float32` precision only!** The code will use SIMD instructions, so double precision will slow things down, and float16 is not precise enough and has limited support.
+ * **`float32` precision only!** The code will use SIMD instructions, so double precision will
+    slow things down, and `float16` is not precise enough and has limited support.
  * **Fully connect feed forward neural networks only!** No support for LSTM, convolutional layers, RNN or whatever.
  
 ### Loss functions implemented

--- a/examples/example_02.c
+++ b/examples/example_02.c
@@ -66,6 +66,10 @@ int main( int argc, char *argv[] )
     printf("Test loss     : %5.5f\n", results[2] );
     printf("Test accuracy : %5.5f\n", results[3] );
 
+    /* Let's save the neural net and see if we can recreate the result form a saved nn
+     * That test will be done in a separate souce file (example_02b.c) */
+    neuralnet_save( nn, "mushroom-neuralnet.npz");
+
     /* Clean up the resources */
     neuralnet_free( nn );
     npy_array_list_free( filelist );

--- a/examples/example_02b.c
+++ b/examples/example_02b.c
@@ -1,0 +1,85 @@
+#include "npy_array.h"
+#include "npy_array_list.h"
+#include "neuralnet.h"
+#include "neuralnet_predict_batch.h"
+#include "simd.h"
+
+#include "evaluate.h"
+
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+#include <assert.h>
+void local_evaluate( neuralnet_t *nn, const int n_valid_samples, const float *valid_X, const float *valid_Y,
+        metric_func metrics[], float *results )
+{
+    //const int n_input  = nn->layer[0].n_input;
+    const int n_output = nn->layer[nn->n_layers-1].n_output;
+
+    metric_func *mf_ptr = metrics;
+
+    int n_metrics = 0;
+    while ( *mf_ptr++ )
+        n_metrics++;
+
+    float predictions[ n_output * n_valid_samples ];
+    neuralnet_predict_batch( nn, n_valid_samples, valid_X, predictions);
+
+    float local_results[n_metrics];
+    memset( local_results, 0, n_metrics * sizeof(float));
+    for ( int i = 0; i < n_valid_samples; i++ ){
+        float *res = local_results;
+        for ( int j = 0; j < n_metrics; j++ ){
+            float _error = metrics[j]( n_output, predictions + (i*n_output), valid_Y + (i*n_output));
+            *res++ += _error;
+        }
+    }
+
+    float *res = results;
+    for ( int i = 0; i < n_metrics; i++ )
+        *res++ = local_results[i] / (float) n_valid_samples;
+}
+
+int main( int argc, char *argv[] )
+{
+    /* Read the datafile created in python+numpy */
+    npy_array_list_t *filelist = npy_array_list_load( "mushroom_train.npz" );
+    assert( filelist );
+    
+    npy_array_list_t *iter = filelist;
+    npy_array_t *train_X = iter->array;  iter = iter->next;
+    npy_array_t *train_Y = iter->array;  iter = iter->next;
+    npy_array_t *test_X = iter->array;   iter = iter->next;
+    npy_array_t *test_Y = iter->array;
+
+    /* if any of these asserts fails, try to open the weight in python and save with
+     * np.ascontiguousarray( matrix ) */
+    assert( train_X->fortran_order == false );
+    assert( train_Y->fortran_order == false );
+    assert( test_X->fortran_order == false );
+    assert( test_Y->fortran_order == false );
+
+    /* Set up a new Neural Network */
+    neuralnet_t *nn = neuralnet_load( "mushroom-neuralnet.npz");
+    assert( nn );
+
+    const int n_train_samples = train_X->shape[0];
+    const int n_test_samples = test_X->shape[0];
+
+    metric_func metrics[] = { get_metric_func("binary_crossentropy"), get_metric_func( "binary_accuracy"), NULL };
+
+    float results[ 2 * 2 ];
+    local_evaluate( nn, n_train_samples, (float*) train_X->data, (float*) train_Y->data, metrics, results);
+    local_evaluate( nn, n_test_samples, (float*) test_X->data, (float*) test_Y->data, metrics, results + 2);
+
+    printf("Train loss    : %5.5f\n", results[0] );
+    printf("Train accuracy: %5.5f\n", results[1] );
+    printf("Test loss     : %5.5f\n", results[2] );
+    printf("Test accuracy : %5.5f\n", results[3] );
+
+    /* Clean up the resources */
+    neuralnet_free( nn );
+    npy_array_list_free( filelist );
+    return 0;
+}
+

--- a/src/activation.c
+++ b/src/activation.c
@@ -488,12 +488,15 @@ static void sigmoid( const int n, float *y )
 {
     int i = 0;
 #ifdef __AVX2__
+    for ( ; !is_aligned( y + i ); i++)
+        y[i] = 1.0f / (1.0f + expf(-y[i]));
+
     const __m256 one  = _mm256_set1_ps(1.0f);
     const __m256 zero = _mm256_set1_ps(0.0f);
 
     __m256 YMM0, YMM1, YMM2, YMM3;
 
-    for (i = 0; i <= ((n)-16); i += 16) {
+    for (; i <= ((n)-16); i += 16) {
         YMM0 = _mm256_load_ps(y + i);
         YMM1 = _mm256_load_ps(y + i + 8);
         YMM0 = _mm256_sub_ps(zero, YMM0);

--- a/src/evaluate.c
+++ b/src/evaluate.c
@@ -12,7 +12,7 @@
 void evaluate( neuralnet_t *nn, const int n_valid_samples, const float *valid_X, const float *valid_Y,
         metric_func metrics[], float *results )
 {
-#ifndef USE_CBLAS
+#ifndef USE_CBLAS 
     const int n_input  = nn->layer[0].n_input;
 #endif
     const int n_output = nn->layer[nn->n_layers-1].n_output;
@@ -27,6 +27,7 @@ void evaluate( neuralnet_t *nn, const int n_valid_samples, const float *valid_X,
     memset( local_results, 0, n_metrics * sizeof(float));
 #ifdef USE_CBLAS
     float predictions[ n_output * n_valid_samples ];
+    memset( predictions, 0, n_output * n_valid_samples * sizeof(float));
     neuralnet_predict_batch( nn, n_valid_samples, valid_X, predictions);
 #endif
     #pragma omp parallel for reduction(+:local_results[:])
@@ -47,5 +48,4 @@ void evaluate( neuralnet_t *nn, const int n_valid_samples, const float *valid_X,
     float *res = results;
     for ( int i = 0; i < n_metrics; i++ )
         *res++ = local_results[i] / (float) n_valid_samples;
-
 }

--- a/src/evaluate.c
+++ b/src/evaluate.c
@@ -3,6 +3,7 @@
  vim: ts=4 sw=4 softtabstop=4 expandtab 
 */
 #include "evaluate.h"
+#include "neuralnet_predict_batch.h"
 #include "simd.h"
 #include <string.h>
 
@@ -11,7 +12,9 @@
 void evaluate( neuralnet_t *nn, const int n_valid_samples, const float *valid_X, const float *valid_Y,
         metric_func metrics[], float *results )
 {
+#ifndef USE_CBLAS
     const int n_input  = nn->layer[0].n_input;
+#endif
     const int n_output = nn->layer[nn->n_layers-1].n_output;
 
     metric_func *mf_ptr = metrics;
@@ -22,11 +25,18 @@ void evaluate( neuralnet_t *nn, const int n_valid_samples, const float *valid_X,
 
     float local_results[n_metrics];
     memset( local_results, 0, n_metrics * sizeof(float));
+#ifdef USE_CBLAS
+    float predictions[ n_output * n_valid_samples ];
+    neuralnet_predict_batch( nn, n_valid_samples, valid_X, predictions);
+#endif
     #pragma omp parallel for reduction(+:local_results[:])
     for ( int i = 0; i < n_valid_samples; i++ ){
+#ifdef USE_CBLAS
+        float *y_pred = predictions + (i*n_output);
+#else
         SIMD_ALIGN(float y_pred[n_output]);
         neuralnet_predict( nn, valid_X + (i*n_input), y_pred );
-
+#endif
         float *res = local_results;
         for ( int j = 0; j < n_metrics; j++ ){
             float _error = metrics[j]( n_output, y_pred, valid_Y + (i*n_output));

--- a/src/neuralnet.c
+++ b/src/neuralnet.c
@@ -243,7 +243,7 @@ void neuralnet_predict( const neuralnet_t *nn, const float *input, float *out )
 {
     /* These asserts are important - end user may forget to SIMD_ALIGN memory 
        and then there is a extremly hard bug to find - Think before you remove these assert() */
-    assert( is_aligned( out ));
+    // assert( is_aligned( out ));
 
     /* Stack allocating memory */
     /* FIXME: Do this once and once only! */

--- a/src/neuralnet_predict_batch.c
+++ b/src/neuralnet_predict_batch.c
@@ -1,0 +1,133 @@
+/* neuralnet_predict_batch.c - Øystein Schønning-Johansen 2023 */
+/* 
+ vim: ts=4 sw=4 softtabstop=4 expandtab 
+*/
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+#include <cblas.h>
+#include <assert.h>
+#include "neuralnet.h"
+#include "simd.h"
+
+#if 0
+/* This is used for debug */
+static void print_vector( int n, const float *v )
+{
+    printf("[ ");
+    for (int i = 0; i < n; i++ )
+        printf("% .5f ", v[i] );
+    printf("]\n");
+}
+static void print_matrix( int m, int n, const float *v )
+{
+    const float *ptr = v;
+    printf("[\n");
+    for ( int i = 0; i < m; i++ ){
+        printf(" ");
+        print_vector( n, ptr );
+        ptr += n;
+    }
+    printf("]\n");
+}
+#endif
+
+void neuralnet_predict_batch( const neuralnet_t *nn, const int n_samples, const float *inputs, float *output )
+{
+    /* Make some work memory on stack. */
+    int workmem_sz = 0;
+    for( int i = 0; i < nn->n_layers; i++)
+        workmem_sz += nn->layer[i].n_output * n_samples;
+
+    float workmem[ workmem_sz ]; /* can we blow the stack here? */
+    float *activations[nn->n_layers+1];
+    activations[0] = (float*) inputs;
+    activations[1] = workmem;
+
+    /* print_matrix( 2, 6, inputs); */
+
+    for( int i = 1; i < nn->n_layers-1; i++)
+        activations[i+1] = activations[i] + nn->layer[i-1].n_output * n_samples;
+
+    activations[nn->n_layers] = output;
+
+    /* Oh, I have to fill the activations with the biases */
+    for( int i = 0; i < nn->n_layers; i++){
+        const layer_t *layer_ptr = nn->layer + i;
+        const size_t size = layer_ptr->n_output * sizeof(float);
+        for( int j = 0; j < n_samples; j++)
+            memcpy( activations[i+1] + j*layer_ptr->n_output, layer_ptr->bias, size );
+    }
+
+#if 0
+    /*  Test first mult */
+    float *A = inputs;               // 2 x 6
+    float *B = nn->layer[0].weight;  // 6 x 4
+    float *C = activations[1];       // 2 x 4
+
+    cblas_sgemm( CblasRowMajor, CblasNoTrans, CblasNoTrans,
+            2, 4, 6,
+            1.0f,
+            A,
+            6,
+            B,
+            4,
+            1.0f,
+            C,
+            4
+            );
+
+    print_matrix( 2, 4, C );
+#endif
+    /* Then we do the forward calculation */
+    for( int i = 0; i < nn->n_layers; i++){
+        const layer_t *layer_ptr = nn->layer + i;
+        cblas_sgemm( CblasRowMajor, CblasNoTrans, CblasNoTrans,
+                n_samples, layer_ptr->n_output, layer_ptr->n_input,
+                1.0f,                /* alpha (7) */
+                activations[i],      /* A     (8) */
+                layer_ptr->n_input,  /* lda   (9) */
+                layer_ptr->weight,   /* B     (8) */
+                layer_ptr->n_output, /* ldb  (11) Something wrong here? */
+                1.0f,                /* beta (12) */
+                activations[i+1],    /* C    (13) */
+                layer_ptr->n_output  /* ldc  (14) */
+        );
+        /* FIXME: we need a special treatment of softmax */
+        layer_ptr->activation_func( layer_ptr->n_output * n_samples, activations[i+1] );
+    }
+}
+
+#if 0
+int main()
+{
+    neuralnet_t *nn = neuralnet_create( 2, INT_ARRAY( 6, 4, 2 ), STR_ARRAY( "tanh", "sigmoid" ));
+    assert( nn );
+    neuralnet_set_loss( nn, "binary_crossentropy"); /* I actually don't need this */
+    neuralnet_initialize( nn, STR_ARRAY("xavier", "xavier" ));
+
+    /*  Two samples */
+    float SIMD_ALIGN(inputs[]) = {
+        0.3f, 0.5f, 0.2f, 0.2f, 0.0f, 0.8f,
+        0.5f, 0.2f, 0.2f, 0.0f, 0.8f, 0.3f
+    };
+    
+    float SIMD_ALIGN(output[2*2]) = { 0 };
+
+    neuralnet_save( nn, "simple_6_4_2.npz" );
+
+    for ( int i = 0; i < 2; i++ )
+        neuralnet_predict( nn, inputs + i*6, output + i*2 );
+
+    for ( int i = 0; i < 2; i++ )
+        printf("Output %d: %5.5f %5.5f\n", i, output[i*2], output[(i*2)+1]  );
+
+    neuralnet_predict_batch( nn, 2, inputs, output);
+
+    for ( int i = 0; i < 2; i++ )
+        printf("Output %d: %5.5f %5.5f\n", i, output[i*2], output[(i*2)+1]  );
+
+    return 0;
+
+}
+#endif

--- a/src/neuralnet_predict_batch.c
+++ b/src/neuralnet_predict_batch.c
@@ -7,8 +7,11 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
-#include <cblas.h>
 #include <assert.h>
+
+#ifdef USE_CBLAS
+#include <cblas.h>
+#endif
 
 #ifndef USE_CBLAS
 /* This is the primitive implemetation using OpenMP to thread th foward calculation of several samples.

--- a/src/neuralnet_predict_batch.h
+++ b/src/neuralnet_predict_batch.h
@@ -1,0 +1,6 @@
+/* neuralnet_predict_batch.h - Øystein Schønning-Johansen 2023 */
+/* 
+ vim: ts=4 sw=4 softtabstop=4 expandtab 
+*/
+#include "neuralnet.h"
+void neuralnet_predict_batch( const neuralnet_t *nn, const int n_samples, const float *inputs, float *output );


### PR DESCRIPTION
This will address #60 .

There are still some issues.

* There is no support for softmax activation functions as this has we have to calculate the exp()-sum for each sample. (How to solve this?)
* I'm afraid the `workmem` that is used to store the temporary matrices can in some cases be big it there's a lot of samples. This might lead to a stack overflow. How do I fix? I do not want to heap allocate and then free inside the function. Maybe I can pre-allocate and send in a pointer to that memory?
* This, of course, only works when compiled with USE_CBLAS. Can this be fixed in any way?